### PR TITLE
52 min y max de ventana mover a derecha del selector de rango

### DIFF
--- a/app/src/components/ReferenceLampForm.tsx
+++ b/app/src/components/ReferenceLampForm.tsx
@@ -6,7 +6,6 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card"
-import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import {
   Select,
@@ -31,10 +30,6 @@ export function ReferenceLampForm() {
       <CardContent>
         <div className="mb-4">
           <MaterialInput />
-        </div>
-        <div className="grid gap-x-6 grid-cols-2 mb-4">
-          <MinInput />
-          <MaxInput />
         </div>
         <div className="flex justify-center">
           <Button className="leading-tight self-end" size="lg">
@@ -70,42 +65,6 @@ function MaterialInput() {
           ))}
         </SelectContent>
       </Select>
-    </div>
-  )
-}
-
-function MinInput() {
-  const inputId = useId()
-  const rangeMin = useGlobalStore(s => s.rangeMin)
-
-  return (
-    <div className="flex flex-col gap-2">
-      <Label htmlFor={inputId}>Min. wavelength</Label>
-      <Input
-        id={inputId}
-        type="text"
-        value={`${rangeMin} Å`}
-        className="tabular-nums disabled:opacity-100 disabled:cursor-default"
-        disabled
-      />
-    </div>
-  )
-}
-
-function MaxInput() {
-  const inputId = useId()
-  const rangeMax = useGlobalStore(s => s.rangeMax)
-
-  return (
-    <div className="flex flex-col gap-2">
-      <Label htmlFor={inputId}>Max. wavelength</Label>
-      <Input
-        id={inputId}
-        type="text"
-        value={`${rangeMax} Å`}
-        className="tabular-nums disabled:opacity-100 disabled:cursor-default"
-        disabled
-      />
     </div>
   )
 }

--- a/app/src/components/ReferenceLampRange.tsx
+++ b/app/src/components/ReferenceLampRange.tsx
@@ -17,7 +17,7 @@ const getX = (p: SpectrumPoint) => p?.wavelength ?? 0
 const getY = (p: SpectrumPoint) => p?.intensity ?? 0
 
 const height = 150
-const margin = { top: 40, right: 30, bottom: 50, left: 55 }
+const margin = { top: 20, right: 30, bottom: 40, left: 50 }
 
 export function ReferenceLampRange() {
   const patternId = useId()

--- a/app/src/components/ReferenceLampRangeUI.tsx
+++ b/app/src/components/ReferenceLampRangeUI.tsx
@@ -1,14 +1,55 @@
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { useGlobalStore } from "@/hooks/use-global-store"
+import { useId } from "react"
 import { ReferenceLampRange } from "./ReferenceLampRange"
 
 export function ReferenceLampRangeUI() {
     return (
         <div className="flex w-full overflow-hidden">
-            <div className="flex-8" style={{ width: `80%` }}>
+            <div className="flex-8" style={{ width: `90%` }}>
                 <ReferenceLampRange />
             </div>
-            <div className=" bg-green-100 p-4 flex-2 w-[200px]">
-                Botones min y max
+            <div className="m-4 flex-2 w-[200px]">
+                <div className="pb-3"><MinInput /></div>
+                <div className=""><MaxInput /></div>
             </div>
+        </div>
+    )
+}
+
+function MinInput() {
+    const inputId = useId()
+    const rangeMin = useGlobalStore(s => s.rangeMin)
+
+    return (
+        <div className="flex flex-col gap-2">
+            <Label htmlFor={inputId}>Min. wavelength</Label>
+            <Input
+                id={inputId}
+                type="text"
+                value={`${rangeMin} Å`}
+                className="tabular-nums disabled:opacity-100 disabled:cursor-default"
+                disabled
+            />
+        </div>
+    )
+}
+
+function MaxInput() {
+    const inputId = useId()
+    const rangeMax = useGlobalStore(s => s.rangeMax)
+
+    return (
+        <div className="flex flex-col gap-2">
+            <Label htmlFor={inputId}>Max. wavelength</Label>
+            <Input
+                id={inputId}
+                type="text"
+                value={`${rangeMax} Å`}
+                className="tabular-nums disabled:opacity-100 disabled:cursor-default"
+                disabled
+            />
         </div>
     )
 }

--- a/app/src/components/ReferenceLampRangeUI.tsx
+++ b/app/src/components/ReferenceLampRangeUI.tsx
@@ -1,0 +1,7 @@
+import { ReferenceLampForm } from "./ReferenceLampForm"
+
+export function ReferenceLampRangeUI() {
+    return (
+        <ReferenceLampForm />
+    )
+}

--- a/app/src/components/ReferenceLampRangeUI.tsx
+++ b/app/src/components/ReferenceLampRangeUI.tsx
@@ -1,7 +1,14 @@
-import { ReferenceLampForm } from "./ReferenceLampForm"
+import { ReferenceLampRange } from "./ReferenceLampRange"
 
 export function ReferenceLampRangeUI() {
     return (
-        <ReferenceLampForm />
+        <div className="flex w-full overflow-hidden">
+            <div className="flex-8" style={{ width: `80%` }}>
+                <ReferenceLampRange />
+            </div>
+            <div className=" bg-green-100 p-4 flex-2 w-[200px]">
+                Botones min y max
+            </div>
+        </div>
     )
 }

--- a/app/src/components/StepCalibration.tsx
+++ b/app/src/components/StepCalibration.tsx
@@ -3,10 +3,10 @@ import { ContinueButton } from "@/components/ContinueButton"
 import { FitsLoader } from "@/components/FitsLoader"
 import { InferenceForm } from "@/components/InferenceForm"
 import { ReferenceLampForm } from "@/components/ReferenceLampForm"
-import { ReferenceLampRange } from "@/components/ReferenceLampRange"
 import { ReferenceLampSpectrum } from "@/components/ReferenceLampSpectrum"
 import { useState } from "react"
 import { Pane, ResizablePanes } from "resizable-panes-react"
+import { ReferenceLampRangeUI } from "./ReferenceLampRangeUI"
 import { CardTitle } from "./ui/card"
 
 interface StageProps {
@@ -30,7 +30,7 @@ export function StepCalibration({ onComplete }: StageProps) {
                 </Pane>
                 <Pane id="P1" size={70} minSize={20} className="bg-gray-100 p-4">
                     <CardTitle>Teorical Comparison Lamp</CardTitle>
-                    <ReferenceLampRange />
+                    <ReferenceLampRangeUI />
                     <div className="flex flex-col h-screen">
                         <div className="flex-1">
                             <ReferenceLampSpectrum />


### PR DESCRIPTION
Complete #52. Los inputs informativos se acomodaron a la derecha del selector de rango teórico.