### PR TITLE
55 barra de navegacion remplazar numeros por nombre de etapa

### DIFF
--- a/app/src/components/NavigationProgressBar.tsx
+++ b/app/src/components/NavigationProgressBar.tsx
@@ -104,10 +104,7 @@ export function NavigationProgressBar({ stepsArr, initialStep }: NavigationProgr
                 </Button>
             </div>
 
-            <h1 className="pt-8 text-center text-4xl font-bold tracking-tight lg:text-5xl">
-                {stepsArr[progress].name}
-            </h1>
-            <div className="pb-6">
+            <div className="pt-8 pb-6">
                 {stepsArr[progress].content}
             </div>
 

--- a/app/src/components/NavigationProgressBar.tsx
+++ b/app/src/components/NavigationProgressBar.tsx
@@ -77,7 +77,7 @@ export function NavigationProgressBar({ stepsArr, initialStep }: NavigationProgr
                                 }}
                                 aria-disabled={disabledItem(index)}
                                 className={
-                                    `flex items-center justify-center w-8 h-8 rounded-lg
+                                    `flex items-center justify-center p-2 rounded-lg
 
                                 ${index <= progress
                                         ? "bg-blue-500 text-white"
@@ -90,7 +90,7 @@ export function NavigationProgressBar({ stepsArr, initialStep }: NavigationProgr
                                     top: "-50%",
                                 }}
                             >
-                                {index}
+                                {step.name}
                             </div>
                         ))}
                     </div>

--- a/app/src/components/NavigationProgressBar.tsx
+++ b/app/src/components/NavigationProgressBar.tsx
@@ -77,8 +77,11 @@ export function NavigationProgressBar({ stepsArr, initialStep }: NavigationProgr
                                 }}
                                 aria-disabled={disabledItem(index)}
                                 className={
-                                    `flex items-center justify-center p-2 rounded-lg
-
+                                    `flex items-center justify-center p-2 rounded-lg 
+                                ${progress === index
+                                        ? "border border-black"
+                                        : "border border-gray-300"
+                                    }
                                 ${index <= progress
                                         ? "bg-blue-500 text-white"
                                         : "bg-gray-300 text-black"

--- a/app/src/components/NavigationProgressBar.tsx
+++ b/app/src/components/NavigationProgressBar.tsx
@@ -86,7 +86,7 @@ export function NavigationProgressBar({ stepsArr, initialStep }: NavigationProgr
                                         ? "bg-blue-500 text-white"
                                         : "bg-gray-300 text-black"
                                     }
-                                ${disabledItem(index) ? "cursor-not-allowed opacity-50" : ""}`
+                                ${disabledItem(index) ? "cursor-not-allowed opacity-50" : "cursor-pointer"}`
                                 }
                                 style={{
                                     position: "relative",


### PR DESCRIPTION
Complete #55. Ahora en los items de navegación aparecen directamente los nombres de cada etapa, Se agrega un borde negro sobre el item seleccionado.